### PR TITLE
Add pkgdown site configuration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@ NEWS\.md
 ^revdep$
 ^README-.*\.png$
 devscripts/*
+^_pkgdown\.yml$

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,15 @@
+url: https://jbkunst.github.io/rchess/
+template:
+  bootstrap: 5
+reference:
+  - title: Chess game
+    contents:
+      - Chess
+  - title: Boards and plots
+    contents:
+      - chessboardjs
+      - ggchessboard
+  - title: Shiny
+    contents:
+      - chessboardjsOutput
+      - renderChessboardjs


### PR DESCRIPTION
## Summary

- add a minimal pkgdown configuration using Bootstrap 5
- organize the reference index into the core Chess API, plotting, and Shiny helpers
- define the GitHub Pages site URL
- exclude `_pkgdown.yml` from package builds

The configuration stays intentionally small so the existing package documentation remains the source of truth.
