### PR TITLE
Add smoke tests for the core Chess API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,7 @@ Imports:
     dplyr,
     assertthat,
     stringr
+Suggests:
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3
 RoxygenNote: 5.0.1

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(rchess)
+
+test_check("rchess")

--- a/tests/testthat/test-chess.R
+++ b/tests/testthat/test-chess.R
@@ -1,0 +1,27 @@
+starting_fen <- "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+test_that("Chess initializes the standard position", {
+  game <- Chess$new()
+
+  expect_equal(game$fen(), starting_fen)
+  expect_equal(game$turn(), "w")
+  expect_length(game$history(), 0)
+  expect_true("e4" %in% game$moves())
+})
+
+test_that("moves update history, turn, and board state", {
+  game <- Chess$new()
+
+  expect_invisible(game$move("e4"))
+  expect_equal(game$turn(), "b")
+  expect_equal(game$history(), "e4")
+  expect_false(identical(game$fen(), starting_fen))
+
+  game$undo()
+  expect_equal(game$fen(), starting_fen)
+  expect_equal(game$turn(), "w")
+})
+
+test_that("invalid FEN strings are rejected", {
+  expect_error(Chess$new("not-a-fen"))
+})


### PR DESCRIPTION
## Summary

- add testthat 3 infrastructure
- test the standard starting position
- test move/history/turn/FEN behavior and undo
- verify invalid FEN input is rejected

These tests are deliberately small and focus on the public R6 API that later compatibility refactors must preserve.
