### PR TITLE
Modernize dplyr and tibble compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,7 @@ Imports:
     assertthat,
     stringr,
     tibble
+Suggests:
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3
 RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,5 +21,6 @@ Imports:
     plyr,
     dplyr,
     assertthat,
-    stringr
+    stringr,
+    tibble
 RoxygenNote: 5.0.1

--- a/R/chess.R
+++ b/R/chess.R
@@ -1,4 +1,6 @@
-from <- to <- number_move <- NULL
+from <- to <- number_move <- color <- san <- start_position <- status <- NULL
+number_move_capture <- piece <- name <- piece_number_move <- captured_by <- .id <- NULL
+
 #' Chess Class
 #'
 #' Chees class.
@@ -81,7 +83,10 @@ Chess <- R6::R6Class(
     history = function(verbose = FALSE){
       private$ct$assign("verb", verbose)
       res <- private$ct$get("chess.history({ verbose: verb })")
-      if (verbose) res <- dplyr::tbl_df(res) %>% mutate(number_move = seq(nrow(.)))
+      if (verbose) {
+        res <- tibble::as_tibble(res)
+        res <- dplyr::mutate(res, number_move = seq_len(nrow(res)))
+      }
       res
     },
     game_over = function(){
@@ -115,7 +120,7 @@ Chess <- R6::R6Class(
     moves = function(verbose = FALSE){
       private$ct$assign("verb", verbose)
       res <- private$ct$get("chess.moves({ verbose: verb })")
-      if (verbose) res <- dplyr::tbl_df(res)
+      if (verbose) res <- tibble::as_tibble(res)
       res
     },
     validate_fen = function(fen){
@@ -218,8 +223,11 @@ Chess <- R6::R6Class(
   if (any(str_detect(dfhist[["san"]], "O-O"))) {
 
     # check if there is castlings for white
-    if (nrow(dfhist %>% filter_("color == \"w\"", "stringr::str_detect(san, \"O-O\")")) == 1) {
-      row <- (dfhist %>% filter_("color == \"w\"", "stringr::str_detect(san, \"O-O\")"))[["number_move"]]
+    white_castling <- dfhist %>%
+      dplyr::filter(color == "w", stringr::str_detect(san, "O-O"))
+
+    if (nrow(white_castling) == 1) {
+      row <- white_castling[["number_move"]]
 
       san_aux <- dfhist[["san"]][row]
       flag_aux <- dfhist[["flags"]][row]
@@ -228,14 +236,17 @@ Chess <- R6::R6Class(
 
       dfhist <- plyr::rbind.fill(
         dfhist[1:row, ],
-        data_frame(color = "w", from = from_aux, to = to_aux, flags = flag_aux,
-                   piece = "r", san = san_aux, captured = NA, number_move = row),
+        tibble::tibble(color = "w", from = from_aux, to = to_aux, flags = flag_aux,
+                       piece = "r", san = san_aux, captured = NA, number_move = row),
         dfhist[(row + 1):nrow(dfhist), ])
     }
 
     # check if there is castling for black
-    if (nrow(dfhist %>% filter_("color == \"b\"", "stringr::str_detect(san, \"O-O\")")) == 1) {
-      row <- (dfhist %>% filter_("color == \"b\"", "stringr::str_detect(san, \"O-O\")"))[["number_move"]]
+    black_castling <- dfhist %>%
+      dplyr::filter(color == "b", stringr::str_detect(san, "O-O"))
+
+    if (nrow(black_castling) == 1) {
+      row <- black_castling[["number_move"]]
 
       san_aux <- dfhist[["san"]][row]
       flag_aux <- dfhist[["flags"]][row]
@@ -244,16 +255,14 @@ Chess <- R6::R6Class(
 
       dfhist <- plyr::rbind.fill(
         dfhist[1:row, ],
-        data_frame(color = "b", from = from_aux, to = to_aux, flags = flag_aux,
-                   piece = "r", san = san_aux, captured = NA, number_move = row),
+        tibble::tibble(color = "b", from = from_aux, to = to_aux, flags = flag_aux,
+                       piece = "r", san = san_aux, captured = NA, number_move = row),
         dfhist[(row + 1):nrow(dfhist), ])
 
     }
   }
 
-  dfhist <- tbl_df(dfhist)
-
-  dfhist
+  tibble::as_tibble(dfhist)
 }
 
 #' @importFrom graphics text
@@ -268,7 +277,7 @@ Chess <- R6::R6Class(
                        paste0(letters[seq(8)], 2),
                        paste0(letters[seq(8)], 1))
 
-  df_start_positions <- data_frame("start_position" = start_positions)
+  df_start_positions <- tibble::tibble("start_position" = start_positions)
 
   names(start_positions) <- start_positions
 
@@ -293,7 +302,7 @@ Chess <- R6::R6Class(
         game_is_over <- TRUE
 
         if (is.null(nrow(df_path))) {
-          df_path <- data_frame(from = pos_current, status = "game over")
+          df_path <- tibble::tibble(from = pos_current, status = "game over")
         } else {
           df_path <- df_path %>% mutate(status = c(rep(NA, nrow(df_path) - 1), "game over"))
         }
@@ -306,9 +315,9 @@ Chess <- R6::R6Class(
         piece_was_captured <- TRUE
 
         if (is.null(nrow(df_path))) {
-          df_path <- data_frame(from = pos_current,
-                                status = "captured",
-                                number_move_capture = dfhist_aux$number_move)
+          df_path <- tibble::tibble(from = pos_current,
+                                    status = "captured",
+                                    number_move_capture = dfhist_aux$number_move)
         } else {
           df_path <- df_path %>%
             mutate(status = c(rep(NA, nrow(df_path) - 1), "captured"),
@@ -319,9 +328,9 @@ Chess <- R6::R6Class(
       }
 
       df_path <- rbind(df_path,
-                       data_frame(from = pos_current,
-                                  to = dfhist_aux$to,
-                                  number_move = dfhist_aux$number_move))
+                       tibble::tibble(from = pos_current,
+                                      to = dfhist_aux$to,
+                                      number_move = dfhist_aux$number_move))
 
       pos_current <- dfhist_aux$to
       pos_nummove <- dfhist_aux$number_move
@@ -333,30 +342,34 @@ Chess <- R6::R6Class(
   }, dfhist)
 
   # rename id var
-  df_paths <- tbl_df(df_paths) %>% rename_("start_position" = ".id")
+  df_paths <- tibble::as_tibble(df_paths) %>%
+    dplyr::rename(start_position = .id)
 
   # calculating moves per pieces
   df_paths <- df_paths %>%
-    group_by_("start_position") %>%
+    dplyr::group_by(start_position) %>%
     mutate(piece_number_move = row_number()) %>%
     ungroup() %>%
-    arrange_("start_position")
+    dplyr::arrange(start_position)
 
-  df_paths <- full_join(.chesspiecedata() %>% select_("piece" = "name", "start_position"),
+  df_paths <- full_join(.chesspiecedata() %>%
+                          dplyr::select(piece = name, start_position),
                         df_paths,
                         by = "start_position")
 
   if (!"number_move_capture" %in% names(df_paths)) df_paths[["number_move_capture"]] <- NA
 
-  df_paths <- cbind(df_paths %>% select_("-start_position", "-status", "-number_move_capture"),
-                    df_paths %>% select_("status", "number_move_capture"))
+  df_paths <- cbind(df_paths %>%
+                      dplyr::select(-start_position, -status, -number_move_capture),
+                    df_paths %>%
+                      dplyr::select(status, number_move_capture))
 
-  df_paths <- tbl_df(df_paths)
+  df_paths <- tibble::as_tibble(df_paths)
 
   # adding the pieces was capture the others
   df_capture <- df_paths %>%
     filter(number_move %in% na.omit(df_paths$number_move_capture)) %>%
-    select_("captured_by" = "piece", "number_move_capture" = "number_move")
+    dplyr::select(captured_by = piece, number_move_capture = number_move)
 
   df_paths <- df_paths %>%
     left_join(df_capture, by = "number_move_capture")

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -40,14 +40,14 @@
                B  = "\u2657", b = "\u265D",
                N  = "\u2658", n = "\u265E")
 
-  dfpieces <- data_frame(
+  dfpieces <- tibble::tibble(
     fen,
     start_position,
     name,
     name_long,
     color = c(rep("w", 16), rep("b", 16))) %>%
-    left_join(data_frame(fen = names(unicode),
-                         unicode = unicode), by = "fen") %>%
+    left_join(tibble::tibble(fen = names(unicode),
+                             unicode = unicode), by = "fen") %>%
     mutate(name_short = paste(fen, start_position))
 
   dfpieces
@@ -66,19 +66,19 @@
               B  = "\u2657", b = "\u265D",
               N  = "\u2658", n = "\u265E")
 
-  dpieces <- dplyr::data_frame(piece = names(pieces),
-                               text = pieces)
+  dpieces <- tibble::tibble(piece = names(pieces),
+                            text = pieces)
 
-  dchess <- dplyr::data_frame(idcell = seq(64),
-                              col    = rep(cols, times = 8),
-                              row    = rep(seq(8), each = 8),
-                              x      = rep(rows, times = 8),
-                              y      = rep(seq(8), each = 8),
-                              cell   = paste0(col, row),
-                              cc     = ifelse((x + y) %% 2, "w", "b"))
+  dchess <- tibble::tibble(idcell = seq(64),
+                           col    = rep(cols, times = 8),
+                           row    = rep(seq(8), each = 8),
+                           x      = rep(rows, times = 8),
+                           y      = rep(seq(8), each = 8),
+                           cell   = paste0(col, row),
+                           cc     = ifelse((x + y) %% 2, "w", "b"))
 
-  dfen <- dplyr::data_frame(idcell = rep(seq(8), 8) + rep(7:0, each = 8)*8,
-                            piece  = .parse_fen(fen))
+  dfen <- tibble::tibble(idcell = rep(seq(8), 8) + rep(7:0, each = 8)*8,
+                         piece  = .parse_fen(fen))
 
   dchess <- dchess %>%
     dplyr::left_join(dfen, by = "idcell") %>%

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(rchess)
+
+test_check("rchess")

--- a/tests/testthat/test-modern-dplyr.R
+++ b/tests/testthat/test-modern-dplyr.R
@@ -14,3 +14,13 @@ test_that("verbose methods work after loading PGN", {
   expect_named(history, c("color", "from", "to", "flags", "piece", "san", "number_move"))
   expect_named(detail, c("piece", "from", "to", "number_move", "piece_number_move", "status", "number_move_capture", "captured_by"))
 })
+
+test_that("history detail handles castling", {
+  game <- do.call(Chess[["new"]], list())
+  do.call(game[["load_pgn"]], list("1. e4 e5 2. Nf3 Nc6 3. Bc4 Nf6 4. O-O"))
+
+  detail <- do.call(game[["history_detail"]], list())
+
+  expect_true(tibble::is_tibble(detail))
+  expect_named(detail, c("piece", "from", "to", "number_move", "piece_number_move", "status", "number_move_capture", "captured_by"))
+})

--- a/tests/testthat/test-modern-dplyr.R
+++ b/tests/testthat/test-modern-dplyr.R
@@ -1,0 +1,3 @@
+test_that("PGN compatibility", {
+  expect_true(TRUE)
+})

--- a/tests/testthat/test-modern-dplyr.R
+++ b/tests/testthat/test-modern-dplyr.R
@@ -1,4 +1,16 @@
-test_that("PGN compatibility", {
-  game <- Chess
-  expect_true(inherits(game, "R6ClassGenerator"))
+test_that("verbose methods work after loading PGN", {
+  game <- do.call(Chess[["new"]], list())
+  do.call(game[["load_pgn"]], list("1. e4"))
+
+  moves <- do.call(game[["moves"]], list(verbose = TRUE))
+  history <- do.call(game[["history"]], list(verbose = TRUE))
+  detail <- do.call(game[["history_detail"]], list())
+
+  expect_true(tibble::is_tibble(moves))
+  expect_true(tibble::is_tibble(history))
+  expect_true(tibble::is_tibble(detail))
+
+  expect_named(moves, c("color", "from", "to", "flags", "piece", "san"))
+  expect_named(history, c("color", "from", "to", "flags", "piece", "san", "number_move"))
+  expect_named(detail, c("piece", "from", "to", "number_move", "piece_number_move", "status", "number_move_capture", "captured_by"))
 })

--- a/tests/testthat/test-modern-dplyr.R
+++ b/tests/testthat/test-modern-dplyr.R
@@ -1,3 +1,4 @@
 test_that("PGN compatibility", {
-  expect_true(TRUE)
+  game <- Chess
+  expect_true(inherits(game, "R6ClassGenerator"))
 })


### PR DESCRIPTION
## Summary

- replace `tbl_df()` with `tibble::as_tibble()` and `data_frame()` with `tibble::tibble()` in package code
- replace `filter_()`, `rename_()`, `group_by_()`, `arrange_()`, and `select_()` with current dplyr syntax
- preserve the returned columns and behavior of `moves(verbose = TRUE)`, `history(verbose = TRUE)`, and `history_detail()`
- add `tibble` to Imports and testthat 3 infrastructure
- add PGN-based regression tests for the three verbose/history methods, including the castling path
- keep the public `Chess` API unchanged

`NAMESPACE` was reviewed and does not require a tibble import because tibble calls are namespace-qualified. No runtime namespace shims are used.