### PR TITLE
Modernize the Shiny move-input demo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,6 @@ Imports:
     dplyr,
     assertthat,
     stringr
+Suggests:
+    shiny
 RoxygenNote: 5.0.1

--- a/demo/shiny-ex.R
+++ b/demo/shiny-ex.R
@@ -1,18 +1,42 @@
 library("shiny")
 library("rchess")
 
-ui = shinyUI(fluidPage(
-  chessboardjsOutput('board', width = 300),
-  chessboardjsOutput('board2', width = 300)
-))
+ui <- fluidPage(
+  textInput("move", "Move", placeholder = "e4"),
+  actionButton("make_move", "Move"),
+  chessboardjsOutput("board", width = 300, height = "300px"),
+  verbatimTextOutput("status")
+)
 
-server = function(input, output) {
-  output$board <- renderChessboardjs({
-    chessboardjs("rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2")
+server <- function(input, output, session) {
+  game <- Chess$new()
+  current_fen <- reactiveVal(game$fen())
+  current_history <- reactiveVal(game$history())
+
+  observeEvent(input$make_move, {
+    req(nzchar(input$move))
+
+    if (!input$move %in% game$moves()) {
+      showNotification("Invalid move", type = "error")
+      return()
+    }
+
+    game$move(input$move)
+    current_fen(game$fen())
+    current_history(game$history())
+    updateTextInput(session, "move", value = "")
   })
 
-  output$board2 <- renderChessboardjs({
-    chessboardjs()
+  output$board <- renderChessboardjs({
+    chessboardjs(current_fen(), width = 300, height = 300)
+  })
+
+  output$status <- renderPrint({
+    history <- current_history()
+    list(
+      turn = game$turn(),
+      history = history
+    )
   })
 }
 


### PR DESCRIPTION
## Summary

- turn the existing static Shiny demo into a reactive move-input example
- keep the `Chess` R6 object outside reactive wrappers and use reactive values to invalidate outputs
- validate moves before applying them
- display the current turn and move history
- declare `shiny` in `Suggests`

This demonstrates the pattern requested in issue #11 without changing the package API.

Closes #11
