### PR TITLE
Add WebAssembly package check

### DIFF
--- a/.github/workflows/R-Wasm-check.yaml
+++ b/.github/workflows/R-Wasm-check.yaml
@@ -1,0 +1,26 @@
+# Workflow derived from https://github.com/r-wasm/actions/tree/v3/examples
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+name: R-Wasm-check
+
+permissions:
+  contents: read
+
+jobs:
+  R-Wasm-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build package for WebAssembly
+        uses: r-wasm/actions/build-rwasm@v3
+        with:
+          packages: "."


### PR DESCRIPTION
## Summary

- add a dedicated `R-Wasm-check` GitHub Actions workflow
- follow the same `r-wasm/actions@v3` pattern used in the other maintained packages
- keep WebAssembly compatibility separate from the regular R CMD check and pkgdown workflows

`rchess` imports `V8`, so this PR is intentionally isolated: the workflow can tell us whether that dependency currently blocks a webR/Wasm build without affecting the normal package checks.